### PR TITLE
everything except zooming and panning

### DIFF
--- a/server.R
+++ b/server.R
@@ -9,38 +9,95 @@ fills <- c('not_highlightable', 'highlightable', 'highlighted')
 fills <- factor(fills, levels=fills)
 factpal <- colorFactor(c('white', 'blue', 'red'), fills)
 
+# Provinces
+kProvinces <- c('Zambezia', 'Nampula')
+
 shinyServer(function(input, output) {
 
+  # Read in the shapefiles
+  moz <- readOGR(dsn=('gis/MOZ_adm1.shp'))
+  
+  # Find the provinces of interest
+  sel <- moz$NAME_1 %in% c('Zambezia', 'Nampula')
+  
+  moz@data$default_fill <- fills[1]
+  moz@data[sel, ]$default_fill <- fills[2]
+  
+  # Bounding boxes...
+  # Hardcode the first one.
+  kBounds <- c(21.5332, -26.94166, 49.52637, -10.35815)
+  bounds[[1]] <- list(lng1 = kBounds[1], lat1=kBounds[2], lng2=kBounds[3], lat2=kBounds[4])
+  
+  for(province in kProvinces) {
+    
+    province <- 'Zambezia'
+    box <- bbox(moz[moz$NAME_1 == province, ])
+    lng1 <- box['x', 'min']
+    lat1 <- box['y', 'min']
+    lng2 <- box['x', 'max']
+    lat2 <- box['y', 'max']
+    
+    bounds[[length(bounds) + 1]] <- list(lng1=lng1, lat1=lat1, lng2=lng2, lat2=lat2)
+    
+  }
+  names(bounds) <- c('Global', kProvinces)
+  
+  # Split the layers into dynamic and non-dynamic shapes
+  static.portion <- moz[!sel, ]
+  dynamic.portion <- moz[sel, ]
+  
+  moz.adm <- readOGR(dsn=('gis/MOZ_adm2.shp'))
+  moz.adm <- moz.adm[moz.adm@data$NAME_1 %in% kProvinces, ]
+  moz.adm@data$group <- paste0(moz.adm@data$NAME_1, '_adm')
+  
   output$moz.map <- renderLeaflet({
-    
-    # Read in the shapefile
-    moz <- readOGR(dsn=path.expand('gis/MOZ_adm1.shp'))
-    
-    # Find the provinces of interest
-    sel <- moz$NAME_1 %in% c('Zambezia', 'Nampula')
-    
-    moz@data$default_fill <- fills[1]
-    moz@data[sel, ]$default_fill <- fills[2]
-    
-    # Split the layers into dynamic and non-dynamic shapes
-    static.portion <- moz[!sel, ]
-    dynamic.portion <- moz[sel, ]
     
     # Initialize leaflet 
     leaf <- leaflet()
     
     # Add static polygons
-    leaf <- addPolygons(leaf, data=static.portion, weight=1, color = "#000000", fillColor=~factpal(default_fill), fillOpacity=0.4)
-    
+    leaf <- addPolygons(leaf, data=static.portion, weight=1, group="static", color = "#000000", fillColor=~factpal(default_fill), fillOpacity=0.4)
     
     # Add dynamic polygons
-    leaf <- addPolygons(leaf, data=dynamic.portion, weight=1, color = "#000000", fillColor=~factpal(default_fill), fillOpacity=0.4, highlightOptions = highlightOptions(
+    leaf <- addPolygons(leaf, data=dynamic.portion, layer = ~NAME_1, group = ~NAME_1, weight=1, color = "#000000", fillColor=~factpal(default_fill), fillOpacity=0.4, highlightOptions = highlightOptions(
       color='#000000', opacity = 1, weight = 1, fillColor = "#FF0000", fillOpacity = 1))
     
-    # In the above code, we'll probably factor out the graphical parameters as this file grows in complexity
-
-  })
+    # Add adm2 polygons with clever group names...
+    leaf <- addPolygons(leaf, data=moz.adm, group = ~group, weight=1, color="#000000", fillColor='blue', fillOpacity = 0.4)
+    hideGroup(leaf, paste0(kProvinces, '_adm'))
     
+    # In the above code, we'll probably factor out the graphical parameters as this file grows in complexity
+  })
+  
+  
+  # Take a crack at handling clicks.  This clicks into a province
+  observe({
+    click <- input$moz.map_shape_click
+    
+    if(is.null(click)) return()
+
+    if(!is.null(click$id)) {
+
+      new.leaf <- leafletProxy('moz.map')
+      showGroup(new.leaf, paste0(click$id, '_adm'))
+      hideGroup(new.leaf, c('static', kProvinces))
+      
+    }
+    
+  })
+
+  # Click back to the full map
+  observe({
+    click <- input$moz.map_click
+    if(is.null(click)) return()
+
+    new.leaf <- leafletProxy('moz.map')
+    setView(new.leaf, lng=(30.21741 + 40.83931) / 2, lat=(-26.86869 + -10.47125)/2, zoom=4)
+    hideGroup(new.leaf, paste0(kProvinces, '_adm'))
+    showGroup(new.leaf, c('static', kProvinces))
+    
+  })
+
 })
 
 


### PR DESCRIPTION
Now!
 * Clicking a province of interest drops the rest of the map, and adds the next adminstrative subdivisions to that province
* Clicking off the province of interest restores the full map view

* Zooming and panning logic is only partially (and incorrectly) implemented, so the app behaves strangely in that regard 